### PR TITLE
AP_ESC_Telem:Fix SITL Crash on M1 Mac caused by floating point to uin…

### DIFF
--- a/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
+++ b/libraries/AP_ESC_Telem/AP_ESC_Telem_SITL.cpp
@@ -42,7 +42,8 @@ void AP_ESC_Telem_SITL::update()
 
 #if HAL_WITH_ESC_TELEM
     for (uint8_t i = 0; i < sitl->state.num_motors; i++) {
-        update_rpm(i, sitl->state.rpm[sitl->state.vtol_motor_start+i]);
+        // update_rpm is expecting an integer while state.rpm stores the values as float
+        update_rpm(i, (int32_t)sitl->state.rpm[sitl->state.vtol_motor_start+i]);
     }
 #endif
 


### PR DESCRIPTION
Discussed in detail on the forum here: https://discuss.ardupilot.org/t/bad-instruction-running-sitl/86112/2

In essence float values were being passed as unsigned 16 bit ints which is likely causing "undefined behaviour" on other architectures, but on the M1 Mac It crashes with a BAD_INSTRUCTION exception. This is probably a floating point error, one of my tests saw this consistently failing when -1 was passed as the RPM. Of course this is not a valid value for an unsigned int. Other architectures may be more forgiving, but this could be causing unexpected values to end up in the AP_ESC_Telem_Backend state[]. This is likely also a problem if an RPM of > 65535 is passed.

In general, it seems that front end code is calculating RPM as integers and then its being stored on the backend as floats and probably surfaces in mavlink and logs as floats values, but will almost never contain fractional rpm or rpm > 65535. 

Therefore, my proposal is not fix the 'big' problem which would affect a lot of code, and simply to make sure that when update_rpm() is called, it will work reliably pass the supplied values down to the backend. There seems to be no good reason for passing uint16_t values as they are almost always going to be passed as integers under the covers anyway, there is no space saving and no performance benefit to the current approach. 